### PR TITLE
OBM-3057 Add pickaxe id to manifest request

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>mn.foreman</groupId>
     <artifactId>windows-agent</artifactId>
-    <version>1.5.1</version>
+    <version>1.6.0</version>
     <name>windows-agent</name>
     <description>The Foreman Windows agent</description>
 
@@ -39,7 +39,7 @@
     <properties>
         <java.version>11</java.version>
 
-        <foreman.version>1.38.0</foreman.version>
+        <foreman.version>1.86.0</foreman.version>
         <commons-io.version>2.11.0</commons-io.version>
         <zip4j.version>2.11.1</zip4j.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>mn.foreman</groupId>
     <artifactId>windows-agent</artifactId>
-    <version>1.6.0</version>
+    <version>1.6.0-SNAPSHOT</version>
     <name>windows-agent</name>
     <description>The Foreman Windows agent</description>
 

--- a/src/main/java/mn/foreman/windowsagent/upgrade/UpgradeTask.java
+++ b/src/main/java/mn/foreman/windowsagent/upgrade/UpgradeTask.java
@@ -10,9 +10,14 @@ import org.apache.tomcat.util.http.fileupload.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.client.RestTemplate;
+import org.yaml.snakeyaml.Yaml;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -30,6 +35,12 @@ public class UpgradeTask {
     /** The logger for this class. */
     private static final Logger LOG =
             LoggerFactory.getLogger(UpgradeTask.class);
+
+    /** The pickaxe install folder prefix used to locate {@code pickaxe.yml}. */
+    private static final String PICKAXE_FOLDER_PREFIX = "foreman-pickaxe-";
+
+    /** The pickaxe configuration file name. */
+    private static final String PICKAXE_YML = "pickaxe.yml";
 
     /** Where the agent lives. */
     private final String agentDist;
@@ -88,39 +99,134 @@ public class UpgradeTask {
 
     /** Checks for an upgrade. */
     public void check() {
-        // Determine which applications are being auto-upgraded
-        final AppManifest[] appManifests =
-                this.restTemplate.getForObject(
-                        this.appsManifest,
-                        AppManifest[].class);
-
         final Map<String, Map<String, String>> versions =
                 this.versionFactory.getVersions();
 
-        // Check and upgrade each, as needed
-        if (appManifests != null) {
-            final List<AppManifest> windowsApps =
-                    Arrays.stream(appManifests)
-                            .filter(appManifest -> appManifest.windows)
-                            .collect(Collectors.toList());
+        this.identifiers
+                .forEach(identifier -> {
+                    final String identifierString =
+                            Integer.toString(identifier);
+                    final String dist =
+                            this.agentDist + File.separator + identifier;
 
-            this.identifiers
-                    .forEach(identifier -> {
-                        final String identifierString =
-                                Integer.toString(identifier);
-                        final String dist =
-                                this.agentDist + File.separator + identifier;
-                        checkManifest(
-                                identifierString,
-                                windowsApps,
-                                dist,
-                                versions.computeIfAbsent(
-                                        identifierString,
-                                        s -> new ConcurrentHashMap<>()));
-                    });
-        } else {
-            LOG.warn("Failed to obtain app manifests from {}", this.appsManifest);
+                    final String pickaxeKey =
+                            findPickaxeIdInDist(dist).orElse("");
+                    final String url =
+                            buildManifestUrl(this.appsManifest, pickaxeKey);
+
+                    final AppManifest[] appManifests =
+                            this.restTemplate.getForObject(
+                                    url,
+                                    AppManifest[].class);
+                    if (appManifests == null) {
+                        LOG.warn("Failed to obtain app manifests from {}", url);
+                        return;
+                    }
+
+                    final List<AppManifest> windowsApps =
+                            Arrays.stream(appManifests)
+                                    .filter(appManifest -> appManifest.windows)
+                                    .collect(Collectors.toList());
+
+                    checkManifest(
+                            identifierString,
+                            windowsApps,
+                            dist,
+                            versions.computeIfAbsent(
+                                    identifierString,
+                                    s -> new ConcurrentHashMap<>()));
+                });
+    }
+
+    /**
+     * Appends the {@code pickaxe_key} query parameter to the configured
+     * manifest URL, using {@code &} or {@code ?} as appropriate.  When
+     * {@code pickaxeKey} is empty (i.e. no pickaxe is currently installed
+     * for this identifier and so we have no key to send), the base URL is
+     * returned unchanged.
+     *
+     * @param base       The base manifest URL.
+     * @param pickaxeKey The pickaxe key to append (may be empty).
+     *
+     * @return The URL with the pickaxe key embedded as a query parameter,
+     *         or the base URL unchanged when no key is available.
+     */
+    private static String buildManifestUrl(
+            final String base,
+            final String pickaxeKey) {
+        if (pickaxeKey.isEmpty()) {
+            return base;
         }
+        final String separator = base.contains("?") ? "&" : "?";
+        return base
+                + separator
+                + "pickaxe_key="
+                + URLEncoder.encode(pickaxeKey, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Searches for an installed pickaxe inside the provided per-identifier
+     * dist folder and, if found, extracts the {@code pickaxeId} value from
+     * its {@code conf/pickaxe.yml}.
+     *
+     * @param dist The per-identifier dist folder
+     *             (e.g. {@code <agentDist>/<identifier>}).
+     *
+     * @return The pickaxe ID, if one could be resolved.
+     */
+    private static Optional<String> findPickaxeIdInDist(final String dist) {
+        final File distRoot = new File(dist);
+        if (!distRoot.isDirectory()) {
+            return Optional.empty();
+        }
+        final File[] appDirs =
+                distRoot.listFiles(file ->
+                        file.isDirectory()
+                                && file.getName().startsWith(
+                                        PICKAXE_FOLDER_PREFIX));
+        if (appDirs == null) {
+            return Optional.empty();
+        }
+        for (final File appDir : appDirs) {
+            final File ymlFile =
+                    new File(
+                            appDir,
+                            "conf" + File.separator + PICKAXE_YML);
+            final Optional<String> pickaxeId = readPickaxeId(ymlFile);
+            if (pickaxeId.isPresent()) {
+                return pickaxeId;
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Reads the {@code pickaxeId} field from the provided {@code pickaxe.yml}
+     * file.
+     *
+     * @param ymlFile The {@code pickaxe.yml} file to read.
+     *
+     * @return The pickaxe ID, if present and non-empty.
+     */
+    private static Optional<String> readPickaxeId(final File ymlFile) {
+        if (!ymlFile.isFile()) {
+            return Optional.empty();
+        }
+        try (InputStream in = new FileInputStream(ymlFile)) {
+            final Object parsed = new Yaml().load(in);
+            if (parsed instanceof Map) {
+                final Object value = ((Map<?, ?>) parsed).get("pickaxeId");
+                if (value != null) {
+                    final String pickaxeId = value.toString();
+                    if (!pickaxeId.isEmpty()) {
+                        return Optional.of(pickaxeId);
+                    }
+                }
+            }
+        } catch (final Exception e) {
+            LOG.warn("Failed to read pickaxe ID from {}", ymlFile, e);
+        }
+        return Optional.empty();
     }
 
     /**

--- a/src/main/java/mn/foreman/windowsagent/upgrade/UpgradeTask.java
+++ b/src/main/java/mn/foreman/windowsagent/upgrade/UpgradeTask.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.client.RestTemplate;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -213,7 +214,7 @@ public class UpgradeTask {
             return Optional.empty();
         }
         try (InputStream in = new FileInputStream(ymlFile)) {
-            final Object parsed = new Yaml().load(in);
+            final Object parsed = new Yaml(new SafeConstructor()).load(in);
             if (parsed instanceof Map) {
                 final Object value = ((Map<?, ?>) parsed).get("pickaxeId");
                 if (value != null) {

--- a/src/test/java/mn/foreman/windowsagent/AppFolderTest.java
+++ b/src/test/java/mn/foreman/windowsagent/AppFolderTest.java
@@ -1,0 +1,31 @@
+package mn.foreman.windowsagent;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/** Unit tests for {@link AppFolder}. */
+class AppFolderTest {
+
+    /** Verifies the {@link AppFolder#BIN} folder name. */
+    @Test
+    void binFolder() {
+        assertEquals("bin", AppFolder.BIN.getFolder());
+    }
+
+    /** Verifies the {@link AppFolder#CONF} folder name. */
+    @Test
+    void confFolder() {
+        assertEquals("conf", AppFolder.CONF.getFolder());
+    }
+
+    /** Verifies that there are exactly two folders defined. */
+    @Test
+    void valuesAreComplete() {
+        final AppFolder[] values = AppFolder.values();
+        assertEquals(2, values.length);
+        assertNotNull(AppFolder.valueOf("BIN"));
+        assertNotNull(AppFolder.valueOf("CONF"));
+    }
+}

--- a/src/test/java/mn/foreman/windowsagent/FileUtilsTest.java
+++ b/src/test/java/mn/foreman/windowsagent/FileUtilsTest.java
@@ -1,0 +1,125 @@
+package mn.foreman.windowsagent;
+
+import mn.foreman.windowsagent.foreman.AppManifest;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Unit tests for {@link FileUtils}. */
+class FileUtilsTest {
+
+    /** Verifies that {@link FileUtils#forFileIn} visits matching files. */
+    @Test
+    void forFileInVisitsMatchingChildren(@TempDir final Path tempDir) throws Exception {
+        Files.createDirectory(tempDir.resolve("dirA"));
+        Files.createDirectory(tempDir.resolve("dirB"));
+        Files.createFile(tempDir.resolve("file.txt"));
+
+        final Set<String> visited = new HashSet<>();
+        FileUtils.forFileIn(
+                tempDir.toString(),
+                File::isDirectory,
+                file -> visited.add(file.getName()));
+
+        assertEquals(
+                new HashSet<>(java.util.Arrays.asList("dirA", "dirB")),
+                visited);
+    }
+
+    /**
+     * Verifies that {@link FileUtils#forFileIn} silently does nothing when
+     * the path does not exist.
+     */
+    @Test
+    void forFileInIgnoresMissingPath(@TempDir final Path tempDir) {
+        final String missing = tempDir.resolve("does-not-exist").toString();
+
+        final Set<String> visited = new HashSet<>();
+        FileUtils.forFileIn(
+                missing,
+                file -> true,
+                file -> visited.add(file.getName()));
+
+        assertTrue(visited.isEmpty());
+    }
+
+    /**
+     * Verifies that the filter excludes files from being visited.
+     */
+    @Test
+    void forFileInRespectsFilter(@TempDir final Path tempDir) throws Exception {
+        Files.createDirectory(tempDir.resolve("dir"));
+        Files.createFile(tempDir.resolve("a.log"));
+        Files.createFile(tempDir.resolve("b.log"));
+
+        final Set<String> visited = new HashSet<>();
+        FileUtils.forFileIn(
+                tempDir.toString(),
+                file -> file.getName().endsWith(".log"),
+                file -> visited.add(file.getName()));
+
+        assertEquals(
+                new HashSet<>(java.util.Arrays.asList("a.log", "b.log")),
+                visited);
+    }
+
+    /**
+     * Verifies that {@link FileUtils#toFilePath} concatenates the agent home,
+     * alias, version, folder and target as expected.
+     */
+    @Test
+    void toFilePathBuildsExpectedPath() {
+        final AppManifest manifest = new AppManifest();
+        manifest.alias = "foreman-pickaxe";
+
+        final Path path =
+                FileUtils.toFilePath(
+                        "C:\\agent",
+                        manifest,
+                        "1.2.3",
+                        AppFolder.CONF,
+                        "pickaxe.yml");
+
+        final Path expected =
+                Paths.get(
+                        "C:\\agent"
+                                + File.separator
+                                + "foreman-pickaxe-1.2.3"
+                                + File.separator
+                                + "conf"
+                                + File.separator
+                                + "pickaxe.yml");
+        assertEquals(expected, path);
+    }
+
+    /**
+     * Verifies that the bin folder produces the correct sub-path.
+     */
+    @Test
+    void toFilePathHandlesBinFolder() {
+        final AppManifest manifest = new AppManifest();
+        manifest.alias = "windows-agent";
+
+        final Path path =
+                FileUtils.toFilePath(
+                        "/opt/agent",
+                        manifest,
+                        "9.9.9",
+                        AppFolder.BIN,
+                        "service-start.bat");
+
+        assertTrue(path.toString().contains("windows-agent-9.9.9"));
+        assertTrue(path.toString().contains("bin"));
+        assertTrue(path.toString().endsWith("service-start.bat"));
+    }
+}

--- a/src/test/java/mn/foreman/windowsagent/VersionFactoryImplTest.java
+++ b/src/test/java/mn/foreman/windowsagent/VersionFactoryImplTest.java
@@ -1,0 +1,124 @@
+package mn.foreman.windowsagent;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Unit tests for {@link VersionFactoryImpl}. */
+class VersionFactoryImplTest {
+
+    /**
+     * Verifies that an empty/missing dist returns an empty map without
+     * throwing.
+     */
+    @Test
+    void noDistReturnsEmptyMap(@TempDir final Path tempDir) {
+        final VersionFactory factory =
+                new VersionFactoryImpl(
+                        tempDir.resolve("missing").toString());
+
+        final Map<String, Map<String, String>> versions = factory.getVersions();
+        assertNotNull(versions);
+        assertTrue(versions.isEmpty());
+    }
+
+    /**
+     * Verifies that an empty existing dist directory returns an empty map.
+     */
+    @Test
+    void emptyDistReturnsEmptyMap(@TempDir final Path tempDir) {
+        final VersionFactory factory =
+                new VersionFactoryImpl(tempDir.toString());
+
+        assertTrue(factory.getVersions().isEmpty());
+    }
+
+    /**
+     * Verifies that foreman/windows-agent applications under numeric scale
+     * folders are correctly parsed into versions.
+     */
+    @Test
+    void parsesValidScaleFolders(@TempDir final Path tempDir) throws Exception {
+        final Path scaleZero = tempDir.resolve("0");
+        final Path scaleOne = tempDir.resolve("1");
+        Files.createDirectory(scaleZero);
+        Files.createDirectory(scaleOne);
+
+        Files.createDirectory(scaleZero.resolve("foreman-pickaxe-1.0.0"));
+        Files.createDirectory(scaleZero.resolve("foreman-autominer-2.0.0"));
+        Files.createDirectory(scaleZero.resolve("not-a-foreman-app-3.0.0"));
+
+        Files.createDirectory(scaleOne.resolve("windows-agent-9.9.9"));
+        Files.createDirectory(scaleOne.resolve("foreman-pickaxe-1.5.0"));
+
+        final VersionFactory factory =
+                new VersionFactoryImpl(tempDir.toString());
+
+        final Map<String, Map<String, String>> versions = factory.getVersions();
+
+        assertEquals(2, versions.size());
+        assertEquals("1.0.0", versions.get("0").get("foreman-pickaxe"));
+        assertEquals("2.0.0", versions.get("0").get("foreman-autominer"));
+        assertNull(versions.get("0").get("not-a-foreman-app"));
+
+        assertEquals("9.9.9", versions.get("1").get("windows-agent"));
+        assertEquals("1.5.0", versions.get("1").get("foreman-pickaxe"));
+    }
+
+    /**
+     * Verifies that non-numeric folders are skipped.
+     */
+    @Test
+    void ignoresNonNumericTopLevel(@TempDir final Path tempDir) throws Exception {
+        final Path nonNumeric = tempDir.resolve("hello");
+        Files.createDirectory(nonNumeric);
+        Files.createDirectory(nonNumeric.resolve("foreman-pickaxe-1.0.0"));
+
+        final VersionFactory factory =
+                new VersionFactoryImpl(tempDir.toString());
+
+        assertTrue(factory.getVersions().isEmpty());
+    }
+
+    /**
+     * Verifies that folder names not matching the {@code alias-version} pattern
+     * (i.e. not exactly three dash-separated segments) are skipped.
+     */
+    @Test
+    void ignoresFoldersWithUnexpectedSegments(@TempDir final Path tempDir) throws Exception {
+        final Path scale = tempDir.resolve("0");
+        Files.createDirectory(scale);
+
+        Files.createDirectory(scale.resolve("foreman"));
+        Files.createDirectory(scale.resolve("foreman-pickaxe-extra-1.0.0"));
+
+        final VersionFactory factory =
+                new VersionFactoryImpl(tempDir.toString());
+
+        assertTrue(
+                factory.getVersions().isEmpty()
+                        || !factory.getVersions().containsKey("0")
+                        || factory.getVersions().get("0").isEmpty());
+    }
+
+    /**
+     * Verifies that loose files (not directories) are ignored.
+     */
+    @Test
+    void ignoresFiles(@TempDir final Path tempDir) throws Exception {
+        Files.createFile(tempDir.resolve("0"));
+
+        final VersionFactory factory =
+                new VersionFactoryImpl(tempDir.toString());
+
+        assertTrue(factory.getVersions().isEmpty());
+    }
+}

--- a/src/test/java/mn/foreman/windowsagent/foreman/AppManifestTest.java
+++ b/src/test/java/mn/foreman/windowsagent/foreman/AppManifestTest.java
@@ -1,0 +1,90 @@
+package mn.foreman.windowsagent.foreman;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Unit tests for {@link AppManifest}. */
+class AppManifestTest {
+
+    /** The mapper used by these tests. */
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    /** Verifies that a fully-populated manifest can be deserialized. */
+    @Test
+    void deserializesFullManifest() throws Exception {
+        final String json =
+                "{" +
+                        "\"alias\":\"foreman-pickaxe\"," +
+                        "\"app\":\"Foreman Pickaxe\"," +
+                        "\"executable\":\"pickaxe.bat\"," +
+                        "\"version\":\"1.2.3\"," +
+                        "\"windows\":true," +
+                        "\"github\":{" +
+                        "  \"name\":\"foreman-pickaxe-1.2.3.zip\"," +
+                        "  \"zipUrl\":\"https://example.com/pickaxe.zip\"" +
+                        "}," +
+                        "\"conf\":{" +
+                        "  \"file\":\"pickaxe.yml\"," +
+                        "  \"apiKeyPattern\":\"REPLACE_API\"," +
+                        "  \"clientIdPattern\":\"REPLACE_ID\"" +
+                        "}" +
+                        "}";
+
+        final AppManifest manifest =
+                this.mapper.readValue(json, AppManifest.class);
+
+        assertEquals("foreman-pickaxe", manifest.alias);
+        assertEquals("Foreman Pickaxe", manifest.app);
+        assertEquals("pickaxe.bat", manifest.executable);
+        assertEquals("1.2.3", manifest.version);
+        assertTrue(manifest.windows);
+
+        assertNotNull(manifest.github);
+        assertEquals("foreman-pickaxe-1.2.3.zip", manifest.github.name);
+        assertEquals("https://example.com/pickaxe.zip", manifest.github.zipUrl);
+
+        assertNotNull(manifest.conf);
+        assertEquals("pickaxe.yml", manifest.conf.file);
+        assertEquals("REPLACE_API", manifest.conf.apiKeyPattern);
+        assertEquals("REPLACE_ID", manifest.conf.clientIdPattern);
+    }
+
+    /** Verifies that unknown JSON properties do not break deserialization. */
+    @Test
+    void deserializeIgnoresUnknownProperties() throws Exception {
+        final String json =
+                "{\"alias\":\"a\",\"app\":\"b\",\"version\":\"1\",\"windows\":false,\"unknown\":42}";
+
+        final AppManifest manifest =
+                this.mapper.readValue(json, AppManifest.class);
+
+        assertEquals("a", manifest.alias);
+        assertEquals("b", manifest.app);
+        assertEquals("1", manifest.version);
+    }
+
+    /** Verifies that a manifest array can be deserialized. */
+    @Test
+    void deserializesArray() throws Exception {
+        final String json =
+                "[" +
+                        "{\"alias\":\"a\",\"windows\":true}," +
+                        "{\"alias\":\"b\",\"windows\":false}" +
+                        "]";
+
+        final AppManifest[] manifests =
+                this.mapper.readValue(json, AppManifest[].class);
+
+        assertEquals(2, manifests.length);
+        assertEquals("a", manifests[0].alias);
+        assertTrue(manifests[0].windows);
+        assertEquals("b", manifests[1].alias);
+        assertNull(manifests[1].github);
+        assertNull(manifests[1].conf);
+    }
+}

--- a/src/test/java/mn/foreman/windowsagent/process/AppImplTest.java
+++ b/src/test/java/mn/foreman/windowsagent/process/AppImplTest.java
@@ -1,0 +1,154 @@
+package mn.foreman.windowsagent.process;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link AppImpl}.
+ *
+ * <p>These tests exercise the actual fork/stop semantics of {@link AppImpl}.
+ * They are disabled on Windows because the test scripts use a POSIX shell.
+ *
+ * <p>{@link AppImpl#stop()} sleeps for ten seconds after killing the process,
+ * so all stop calls in this class run on a background thread that we
+ * interrupt as soon as we have verified the post-stop state.
+ */
+@DisabledOnOs(OS.WINDOWS)
+class AppImplTest {
+
+    /** Verifies that a fresh app reports as not running. */
+    @Test
+    void reportsNotRunningInitially(@TempDir final Path tempDir) {
+        final ExecutorService executor = Executors.newCachedThreadPool();
+        try {
+            final AppImpl app =
+                    new AppImpl(
+                            "test",
+                            tempDir.resolve("noop"),
+                            executor);
+
+            assertTrue(app.isNotRunning());
+            assertEquals("test", app.getName());
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    /**
+     * Verifies that {@link AppImpl#start()} forks the configured executable
+     * and that {@link AppImpl#stop()} terminates it.
+     */
+    @Test
+    void startAndStopForksAndKillsProcess(@TempDir final Path tempDir) throws Exception {
+        final Path script = createSleepScript(tempDir);
+
+        final ExecutorService executor = Executors.newCachedThreadPool();
+        try {
+            final AppImpl app = new AppImpl("sleeper", script, executor);
+
+            app.start();
+
+            TimeUnit.MILLISECONDS.sleep(250);
+            assertFalse(app.isNotRunning(), "app should be marked running after start");
+
+            stopFastInBackground(app);
+            assertTrue(app.isNotRunning(), "app should be marked stopped after stop");
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    /**
+     * Verifies that calling {@link AppImpl#start()} repeatedly while running
+     * does not produce additional processes (it should be a no-op the second
+     * time).
+     */
+    @Test
+    void startWhileRunningIsNoOp(@TempDir final Path tempDir) throws Exception {
+        final Path script = createSleepScript(tempDir);
+
+        final ExecutorService executor = Executors.newCachedThreadPool();
+        try {
+            final AppImpl app = new AppImpl("sleeper", script, executor);
+
+            app.start();
+            TimeUnit.MILLISECONDS.sleep(150);
+            assertFalse(app.isNotRunning());
+
+            app.start();
+            assertFalse(app.isNotRunning());
+
+            stopFastInBackground(app);
+            assertTrue(app.isNotRunning());
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    /**
+     * Verifies that {@link AppImpl#stop()} on an app that was never started
+     * is safe (no exception, no sleep) and leaves the app in the not-running
+     * state.
+     */
+    @Test
+    void stopWhenNeverStartedIsSafe(@TempDir final Path tempDir) {
+        final ExecutorService executor = Executors.newCachedThreadPool();
+        try {
+            final AppImpl app =
+                    new AppImpl(
+                            "noop",
+                            tempDir.resolve("noop"),
+                            executor);
+
+            app.stop();
+            assertTrue(app.isNotRunning());
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    /** Creates a small POSIX shell script that sleeps when run. */
+    private static Path createSleepScript(final Path tempDir) throws Exception {
+        final Path script = tempDir.resolve("sleeper.sh");
+        Files.write(
+                script,
+                ("#!/bin/sh\n"
+                        + "sleep 30\n").getBytes());
+        if (!script.toFile().setExecutable(true)) {
+            throw new IllegalStateException("Failed to mark script executable");
+        }
+        return script;
+    }
+
+    /**
+     * Runs {@link AppImpl#stop()} on a background thread and then interrupts
+     * the thread so we don't have to wait for the hard-coded 10 second
+     * post-stop sleep.  Returns once the running flag has been flipped.
+     */
+    private static void stopFastInBackground(final AppImpl app) throws Exception {
+        final Thread stopper = new Thread(app::stop);
+        stopper.setDaemon(true);
+        stopper.start();
+
+        // Wait for the running flag to flip before we interrupt the sleep
+        final long deadline = System.currentTimeMillis() + 5_000L;
+        while (!app.isNotRunning() && System.currentTimeMillis() < deadline) {
+            Thread.sleep(25);
+        }
+
+        stopper.interrupt();
+        stopper.join(5_000L);
+    }
+}

--- a/src/test/java/mn/foreman/windowsagent/process/WatchDogTest.java
+++ b/src/test/java/mn/foreman/windowsagent/process/WatchDogTest.java
@@ -1,0 +1,308 @@
+package mn.foreman.windowsagent.process;
+
+import mn.foreman.windowsagent.foreman.AppManifest;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/** Unit tests for {@link WatchDog}. */
+class WatchDogTest {
+
+    /** The shared executor used by tests. */
+    private ExecutorService executor;
+
+    @BeforeEach
+    void setUp() {
+        this.executor = Executors.newCachedThreadPool();
+    }
+
+    @AfterEach
+    void tearDown() {
+        this.executor.shutdownNow();
+    }
+
+    /**
+     * Verifies that {@link WatchDog#stopAll()} on a fresh watchdog with no
+     * apps does not throw.
+     */
+    @Test
+    void stopAllOnEmptyWatchDog() {
+        final WatchDog watchDog = new WatchDog(this.executor);
+        assertDoesNotThrow(watchDog::stopAll);
+    }
+
+    /**
+     * Verifies that {@link WatchDog#stopApp(String, String)} for an unknown
+     * dist or app does not throw.
+     */
+    @Test
+    void stopAppForUnknownDistDoesNothing() {
+        final WatchDog watchDog = new WatchDog(this.executor);
+        assertDoesNotThrow(() -> watchDog.stopApp("nope", "nope"));
+    }
+
+    /**
+     * Verifies that {@link WatchDog#stopApp(String, String)} removes a known
+     * app and invokes {@link App#stop()} on it.
+     */
+    @Test
+    void stopAppRemovesKnownApp() throws Exception {
+        final WatchDog watchDog = new WatchDog(this.executor);
+
+        final App mockApp = mock(App.class);
+        injectApp(watchDog, "dist", "alias", mockApp);
+
+        watchDog.stopApp("dist", "alias");
+
+        verify(mockApp, times(1)).stop();
+        assertNull(getAppMap(watchDog).get("dist").get("alias"));
+    }
+
+    /**
+     * Verifies that {@link WatchDog#stopAll()} stops every known app across
+     * dists.
+     */
+    @Test
+    void stopAllStopsEveryKnownApp() throws Exception {
+        final WatchDog watchDog = new WatchDog(this.executor);
+
+        final App appA = mock(App.class);
+        final App appB = mock(App.class);
+        final App appC = mock(App.class);
+
+        injectApp(watchDog, "distA", "alias-a", appA);
+        injectApp(watchDog, "distA", "alias-b", appB);
+        injectApp(watchDog, "distB", "alias-c", appC);
+
+        watchDog.stopAll();
+
+        verify(appA).stop();
+        verify(appB).stop();
+        verify(appC).stop();
+    }
+
+    /**
+     * Verifies that {@link WatchDog#startApp(String, AppManifest, String)}
+     * is a no-op when the app is already running for the given dist/alias
+     * combination.
+     */
+    @Test
+    void startAppDoesNotRestartRunningApp() throws Exception {
+        final WatchDog watchDog = new WatchDog(this.executor);
+
+        final App existing = mock(App.class);
+        when(existing.isNotRunning()).thenReturn(false);
+        injectApp(watchDog, "dist", "alias", existing);
+
+        final AppManifest manifest = new AppManifest();
+        manifest.alias = "alias";
+        manifest.app = "name";
+        manifest.executable = "noop";
+
+        watchDog.startApp("dist", manifest, "1.0.0");
+
+        verify(existing, never()).restart();
+        assertSame(existing, getAppMap(watchDog).get("dist").get("alias"));
+    }
+
+    /**
+     * Verifies that {@link WatchDog#startApp(String, AppManifest, String)}
+     * restarts an existing app that has stopped (i.e. {@code isNotRunning()}
+     * returns {@code true}).
+     */
+    @Test
+    void startAppRestartsKnownStoppedApp() throws Exception {
+        final WatchDog watchDog = new WatchDog(this.executor);
+
+        final App existing = mock(App.class);
+        when(existing.isNotRunning()).thenReturn(true);
+        injectApp(watchDog, "dist", "alias", existing);
+
+        final AppManifest manifest = new AppManifest();
+        manifest.alias = "alias";
+        manifest.app = "name";
+        manifest.executable = "noop";
+
+        watchDog.startApp("dist", manifest, "1.0.0");
+
+        verify(existing, times(1)).restart();
+    }
+
+    /**
+     * Verifies that {@link WatchDog#startApp(String, AppManifest, String)}
+     * fully integrates with a real {@link AppImpl} by forking a real (cheap)
+     * process and registering it.  Disabled on Windows because the script is
+     * a POSIX shell script.
+     */
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void startAppForksRealProcess(@TempDir final Path tempDir) throws Exception {
+        // Create a real dist layout so FileUtils.toFilePath resolves.
+        // Layout: <dist>/<alias>-<version>/bin/<executable>
+        final String alias = "foreman-pickaxe";
+        final String version = "1.0.0";
+        final Path appDir = tempDir.resolve(alias + "-" + version);
+        final Path binDir = appDir.resolve("bin");
+        Files.createDirectories(binDir);
+        final Path script = binDir.resolve("noop.sh");
+        Files.write(
+                script,
+                ("#!/bin/sh\n"
+                        + "sleep 30\n").getBytes());
+        if (!script.toFile().setExecutable(true)) {
+            throw new IllegalStateException("Failed to mark script executable");
+        }
+
+        final WatchDog watchDog = new WatchDog(this.executor);
+
+        final AppManifest manifest = new AppManifest();
+        manifest.alias = alias;
+        manifest.app = "Pickaxe";
+        manifest.executable = "noop.sh";
+
+        try {
+            watchDog.startApp(tempDir.toString(), manifest, version);
+
+            // The map should now contain the app.
+            final Map<String, Map<String, App>> apps = getAppMap(watchDog);
+            assertNotNull(apps.get(tempDir.toString()));
+            final App app = apps.get(tempDir.toString()).get(alias);
+            assertNotNull(app);
+            assertEquals("Pickaxe", app.getName());
+
+            // It should have been started by the time we get here.
+            TimeUnit.MILLISECONDS.sleep(250);
+            assertFalse(app.isNotRunning());
+        } finally {
+            // Stop in background to skip the 10s sleep.
+            stopAllFast(watchDog);
+        }
+    }
+
+    /**
+     * Verifies that the {@code monitor()} scheduled method restarts apps
+     * that are currently not running.
+     */
+    @Test
+    void monitorRestartsStoppedApps() throws Exception {
+        final WatchDog watchDog = new WatchDog(this.executor);
+
+        final App stopped = mock(App.class);
+        when(stopped.isNotRunning()).thenReturn(true);
+        when(stopped.getName()).thenReturn("stopped");
+
+        final App running = mock(App.class);
+        when(running.isNotRunning()).thenReturn(false);
+        when(running.getName()).thenReturn("running");
+
+        injectApp(watchDog, "dist", "stopped-alias", stopped);
+        injectApp(watchDog, "dist", "running-alias", running);
+
+        invokeMonitor(watchDog);
+
+        verify(stopped, atLeastOnce()).restart();
+        verify(running, never()).restart();
+    }
+
+    /**
+     * Verifies that {@code monitor()} survives a thrown exception from a
+     * single app's {@code restart()}.
+     */
+    @Test
+    void monitorSwallowsRestartExceptions() throws Exception {
+        final WatchDog watchDog = new WatchDog(this.executor);
+
+        final App bad = mock(App.class);
+        when(bad.isNotRunning()).thenReturn(true);
+        when(bad.getName()).thenReturn("bad");
+        org.mockito.Mockito.doThrow(new RuntimeException("boom")).when(bad).restart();
+
+        final App good = mock(App.class);
+        when(good.isNotRunning()).thenReturn(true);
+        when(good.getName()).thenReturn("good");
+
+        injectApp(watchDog, "dist", "bad-alias", bad);
+        injectApp(watchDog, "dist", "good-alias", good);
+
+        assertDoesNotThrow(() -> invokeMonitor(watchDog));
+
+        verify(good, atLeastOnce()).restart();
+    }
+
+    /**
+     * Pre-populates the watchdog's internal map with a known {@link App}.
+     */
+    private static void injectApp(
+            final WatchDog watchDog,
+            final String dist,
+            final String alias,
+            final App app) throws Exception {
+        final Map<String, Map<String, App>> apps = getAppMap(watchDog);
+        apps.computeIfAbsent(dist, k -> new HashMap<>()).put(alias, app);
+    }
+
+    /** Reads the watchdog's internal {@code apps} map via reflection. */
+    @SuppressWarnings("unchecked")
+    private static Map<String, Map<String, App>> getAppMap(
+            final WatchDog watchDog) throws Exception {
+        final Field field = WatchDog.class.getDeclaredField("apps");
+        field.setAccessible(true);
+        return (Map<String, Map<String, App>>) field.get(watchDog);
+    }
+
+    /** Invokes the private {@code monitor()} method via reflection. */
+    private static void invokeMonitor(final WatchDog watchDog) throws Exception {
+        final Method method = WatchDog.class.getDeclaredMethod("monitor");
+        method.setAccessible(true);
+        method.invoke(watchDog);
+    }
+
+    /**
+     * Stops every app in the watchdog on a background thread, interrupting
+     * the {@link AppImpl} 10 second post-stop sleep so the test exits
+     * quickly.
+     */
+    private static void stopAllFast(final WatchDog watchDog) throws Exception {
+        final Thread stopper = new Thread(watchDog::stopAll);
+        stopper.setDaemon(true);
+        stopper.start();
+
+        final Map<String, Map<String, App>> apps = getAppMap(watchDog);
+        final long deadline = System.currentTimeMillis() + 5_000L;
+        while (System.currentTimeMillis() < deadline) {
+            boolean allStopped = true;
+            for (Map<String, App> distApps : apps.values()) {
+                for (App app : distApps.values()) {
+                    if (!app.isNotRunning()) {
+                        allStopped = false;
+                        break;
+                    }
+                }
+            }
+            if (allStopped) {
+                break;
+            }
+            Thread.sleep(25);
+        }
+
+        stopper.interrupt();
+        stopper.join(5_000L);
+    }
+}

--- a/src/test/java/mn/foreman/windowsagent/upgrade/UpgradeTaskTest.java
+++ b/src/test/java/mn/foreman/windowsagent/upgrade/UpgradeTaskTest.java
@@ -1,0 +1,944 @@
+package mn.foreman.windowsagent.upgrade;
+
+import mn.foreman.windowsagent.VersionFactory;
+import mn.foreman.windowsagent.foreman.AppManifest;
+import mn.foreman.windowsagent.process.WatchDog;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+/** Unit tests for {@link UpgradeTask}. */
+class UpgradeTaskTest {
+
+    /** The manifest endpoint used by these tests. */
+    private static final String MANIFEST_URL =
+            "https://example.com/api/manifest";
+
+    /** The zip URL used by these tests. */
+    private static final String ZIP_URL =
+            "https://example.com/foreman-pickaxe-2.0.0.zip";
+
+    /** Mocked rest template. */
+    private RestTemplate restTemplate;
+
+    /** Mocked version factory. */
+    private VersionFactory versionFactory;
+
+    /** Mocked watchdog. */
+    private WatchDog watchDog;
+
+    @BeforeEach
+    void setUp() {
+        this.restTemplate = mock(RestTemplate.class);
+        this.versionFactory = mock(VersionFactory.class);
+        this.watchDog = mock(WatchDog.class);
+    }
+
+    /**
+     * Verifies the full happy-path: a manifest is fetched, a zip is
+     * downloaded and unpacked, the conf file has its placeholders replaced,
+     * the zip is cleaned up, and the watchdog is asked to start the app.
+     */
+    @Test
+    void installsFreshApp(@TempDir final Path tempDir) throws Exception {
+        final AppManifest manifest =
+                buildManifest("2.0.0", "REPLACE_API", "REPLACE_ID");
+        final byte[] zip =
+                buildZip(
+                        manifest.alias + "-" + manifest.version,
+                        "REPLACE_API and REPLACE_ID inside");
+
+        stubManifestResponse(manifest);
+        stubZipResponse(zip);
+
+        when(this.versionFactory.getVersions())
+                .thenReturn(new ConcurrentHashMap<>());
+
+        final UpgradeTask task =
+                new UpgradeTask(
+                        MANIFEST_URL,
+                        tempDir.toString(),
+                        Collections.singletonList(0),
+                        identifier -> "client-" + identifier,
+                        "MY_API_KEY",
+                        this.versionFactory,
+                        this.watchDog,
+                        this.restTemplate);
+
+        task.check();
+
+        // Manifest should have been GET'd against a URL based on the
+        // configured base, with no extra headers (no auth, no client id).
+        verify(this.restTemplate).getForObject(
+                argThat((String url) -> url != null && url.startsWith(MANIFEST_URL)),
+                eq(AppManifest[].class));
+
+        // Zip should have been downloaded
+        verify(this.restTemplate).getForObject(ZIP_URL, byte[].class);
+
+        // Files should exist on disk
+        final Path identifierDir = tempDir.resolve("0");
+        final Path appDir =
+                identifierDir.resolve(manifest.alias + "-" + manifest.version);
+        assertTrue(Files.isDirectory(appDir));
+
+        // Zip file itself should have been cleaned up
+        assertFalse(
+                Files.exists(identifierDir.resolve(manifest.github.name)),
+                "zip should have been deleted after extraction");
+
+        // Conf should have its placeholders replaced
+        final Path confFile = appDir.resolve("conf").resolve(manifest.conf.file);
+        assertTrue(Files.isRegularFile(confFile));
+        final String confContents =
+                Files.readString(confFile);
+        assertTrue(
+                confContents.contains("MY_API_KEY"),
+                "API key should have been substituted: " + confContents);
+        assertTrue(
+                confContents.contains("client-0"),
+                "client id should have been substituted: " + confContents);
+        assertFalse(confContents.contains("REPLACE_API"));
+        assertFalse(confContents.contains("REPLACE_ID"));
+
+        // Watchdog should have been told to stop the app before upgrade and
+        // then start it once installed.
+        final String dist = tempDir + File.separator + "0";
+        verify(this.watchDog).stopApp(dist, manifest.alias);
+        verify(this.watchDog).startApp(dist, manifest, manifest.version);
+    }
+
+    /**
+     * Verifies that nothing is downloaded or installed when the manifest's
+     * version matches the version already on disk and the existing conf is
+     * already configured.
+     */
+    @Test
+    void skipsUpgradeWhenAlreadyOnLatestVersion(@TempDir final Path tempDir) throws Exception {
+        final AppManifest manifest =
+                buildManifest("1.5.0", "REPLACE_API", "REPLACE_ID");
+
+        // Pre-populate dist with the matching version + a clean conf
+        final Path identifierDir = tempDir.resolve("0");
+        final Path appDir =
+                identifierDir.resolve(manifest.alias + "-" + manifest.version);
+        final Path confDir = appDir.resolve("conf");
+        Files.createDirectories(confDir);
+        Files.write(
+                confDir.resolve(manifest.conf.file),
+                "apiKey=ABC\nclientId=DEF".getBytes(StandardCharsets.UTF_8));
+
+        stubManifestResponse(manifest);
+
+        final Map<String, Map<String, String>> versions = new HashMap<>();
+        final Map<String, String> distVersions = new HashMap<>();
+        distVersions.put(manifest.alias, manifest.version);
+        versions.put("0", distVersions);
+        when(this.versionFactory.getVersions()).thenReturn(versions);
+
+        final UpgradeTask task =
+                new UpgradeTask(
+                        MANIFEST_URL,
+                        tempDir.toString(),
+                        Collections.singletonList(0),
+                        identifier -> "client-" + identifier,
+                        "MY_API_KEY",
+                        this.versionFactory,
+                        this.watchDog,
+                        this.restTemplate);
+
+        task.check();
+
+        verify(this.restTemplate, never()).getForObject(anyString(), eq(byte[].class));
+        // No stop/upgrade should have happened
+        verify(this.watchDog, never()).stopApp(anyString(), eq(manifest.alias));
+        // Watchdog should still have been asked to start (the app should be
+        // running even if no upgrade is needed)
+        verify(this.watchDog, times(1)).startApp(
+                tempDir.toString() + File.separator + "0",
+                manifest,
+                manifest.version);
+    }
+
+    /**
+     * Verifies that an existing-but-bad configuration triggers a re-upgrade
+     * even when the version on disk matches the manifest's version.
+     */
+    @Test
+    void reupgradesWhenConfStillContainsPlaceholders(@TempDir final Path tempDir) throws Exception {
+        final AppManifest manifest =
+                buildManifest("3.0.0", "REPLACE_API", "REPLACE_ID");
+
+        // Pre-populate dist with the matching version, but a conf that still
+        // contains the placeholder patterns (i.e. it never got configured)
+        final Path identifierDir = tempDir.resolve("0");
+        final Path appDir =
+                identifierDir.resolve(manifest.alias + "-" + manifest.version);
+        final Path confDir = appDir.resolve("conf");
+        Files.createDirectories(confDir);
+        Files.write(
+                confDir.resolve(manifest.conf.file),
+                "apiKey=REPLACE_API\nclientId=REPLACE_ID"
+                        .getBytes(StandardCharsets.UTF_8));
+
+        // The zip is for the same version but contains a fresh conf
+        final byte[] zip =
+                buildZip(
+                        manifest.alias + "-" + manifest.version,
+                        "apiKey=REPLACE_API\nclientId=REPLACE_ID\nfresh=yes");
+
+        stubManifestResponse(manifest);
+        stubZipResponse(zip);
+
+        final Map<String, Map<String, String>> versions = new HashMap<>();
+        final Map<String, String> distVersions = new HashMap<>();
+        distVersions.put(manifest.alias, manifest.version);
+        versions.put("0", distVersions);
+        when(this.versionFactory.getVersions()).thenReturn(versions);
+
+        final UpgradeTask task =
+                new UpgradeTask(
+                        MANIFEST_URL,
+                        tempDir.toString(),
+                        Collections.singletonList(0),
+                        identifier -> "client-" + identifier,
+                        "MY_API_KEY",
+                        this.versionFactory,
+                        this.watchDog,
+                        this.restTemplate);
+
+        task.check();
+
+        // Should have downloaded the zip (re-upgrade)
+        verify(this.restTemplate, times(1)).getForObject(ZIP_URL, byte[].class);
+        // Conf should be the new one, with placeholders replaced
+        final Path confFile = appDir.resolve("conf").resolve(manifest.conf.file);
+        final String confContents = Files.readString(confFile);
+        assertTrue(confContents.contains("MY_API_KEY"));
+        assertTrue(confContents.contains("client-0"));
+        // Watchdog stop + start
+        verify(this.watchDog).stopApp(
+                tempDir.toString() + File.separator + "0", manifest.alias);
+        verify(this.watchDog).startApp(
+                tempDir.toString() + File.separator + "0",
+                manifest,
+                manifest.version);
+    }
+
+    /**
+     * Verifies that, when an existing app no longer appears in the manifest,
+     * the watchdog is asked to stop it.
+     */
+    @Test
+    void stopsAppsThatHaveBeenRemovedFromManifest(@TempDir final Path tempDir) {
+        final AppManifest manifest =
+                buildManifest("2.0.0", "REPLACE_API", "REPLACE_ID");
+
+        // Manifest only references "foreman-pickaxe", but versionFactory
+        // reports an extra installed app called "foreman-old".
+        stubManifestResponse(manifest);
+
+        final byte[] zip;
+        try {
+            zip = buildZip(
+                    manifest.alias + "-" + manifest.version,
+                    "REPLACE_API REPLACE_ID");
+        } catch (final Exception e) {
+            throw new RuntimeException(e);
+        }
+        stubZipResponse(zip);
+
+        final Map<String, Map<String, String>> versions = new HashMap<>();
+        final Map<String, String> distVersions = new HashMap<>();
+        distVersions.put("foreman-old", "0.0.1");
+        versions.put("0", distVersions);
+        when(this.versionFactory.getVersions()).thenReturn(versions);
+
+        final UpgradeTask task =
+                new UpgradeTask(
+                        MANIFEST_URL,
+                        tempDir.toString(),
+                        Collections.singletonList(0),
+                        identifier -> "client-" + identifier,
+                        "MY_API_KEY",
+                        this.versionFactory,
+                        this.watchDog,
+                        this.restTemplate);
+
+        task.check();
+
+        // The "foreman-old" app should have been stopped because it is
+        // no longer referenced by the manifest
+        verify(this.watchDog).stopApp(
+                tempDir.toString() + File.separator + "0",
+                "foreman-old");
+    }
+
+    /**
+     * Verifies that non-windows manifests are filtered out and nothing is
+     * downloaded for them.
+     */
+    @Test
+    void skipsNonWindowsManifests(@TempDir final Path tempDir) throws Exception {
+        final AppManifest manifest =
+                buildManifest("2.0.0", "REPLACE_API", "REPLACE_ID");
+        manifest.windows = false;
+
+        stubManifestResponse(manifest);
+        when(this.versionFactory.getVersions())
+                .thenReturn(new ConcurrentHashMap<>());
+
+        final UpgradeTask task =
+                new UpgradeTask(
+                        MANIFEST_URL,
+                        tempDir.toString(),
+                        Collections.singletonList(0),
+                        identifier -> "client-" + identifier,
+                        "MY_API_KEY",
+                        this.versionFactory,
+                        this.watchDog,
+                        this.restTemplate);
+
+        task.check();
+
+        verify(this.restTemplate, never()).getForObject(anyString(), eq(byte[].class));
+        verify(this.watchDog, never()).startApp(anyString(), any(), anyString());
+    }
+
+    /**
+     * Verifies that, when no pickaxe install exists for an identifier (so
+     * we have no key to send), the manifest URL is GET'd unchanged - the
+     * {@code pickaxe_key} query parameter is dropped entirely rather than
+     * sent as an empty value.  The GET is a plain {@code getForObject} with
+     * no headers, no auth, no other interactions.
+     */
+    @Test
+    void noPickaxeKeyOmitsQueryParamEntirely(@TempDir final Path tempDir) {
+        stubManifestResponse();
+
+        when(this.versionFactory.getVersions())
+                .thenReturn(new ConcurrentHashMap<>());
+
+        final UpgradeTask task =
+                new UpgradeTask(
+                        MANIFEST_URL,
+                        tempDir.toString(),
+                        Collections.singletonList(0),
+                        identifier -> "client-" + identifier,
+                        "MY_API_KEY",
+                        this.versionFactory,
+                        this.watchDog,
+                        this.restTemplate);
+
+        task.check();
+
+        verify(this.restTemplate, times(1)).getForObject(
+                MANIFEST_URL,
+                AppManifest[].class);
+        verifyNoMoreInteractions(this.restTemplate);
+    }
+
+    /**
+     * Verifies that a {@code null} manifest response body is handled
+     * gracefully (no exceptions, no follow-up downloads).
+     */
+    @Test
+    void nullManifestBodyIsTolerated(@TempDir final Path tempDir) throws Exception {
+        when(this.restTemplate.getForObject(
+                argThat((String url) -> url != null && url.startsWith(MANIFEST_URL)),
+                eq(AppManifest[].class)))
+                .thenReturn(null);
+
+        when(this.versionFactory.getVersions())
+                .thenReturn(new ConcurrentHashMap<>());
+
+        final UpgradeTask task =
+                new UpgradeTask(
+                        MANIFEST_URL,
+                        tempDir.toString(),
+                        Collections.singletonList(0),
+                        identifier -> "client-" + identifier,
+                        "MY_API_KEY",
+                        this.versionFactory,
+                        this.watchDog,
+                        this.restTemplate);
+
+        task.check();
+
+        verify(this.restTemplate, never()).getForObject(ZIP_URL, byte[].class);
+        verify(this.watchDog, never()).startApp(anyString(), any(), anyString());
+    }
+
+    /**
+     * Verifies that, when the zip download returns {@code null}, no upgrade
+     * is performed (the existing install remains untouched).
+     */
+    @Test
+    void missingZipDoesNotCorruptState(@TempDir final Path tempDir) throws Exception {
+        final AppManifest manifest =
+                buildManifest("2.0.0", "REPLACE_API", "REPLACE_ID");
+
+        stubManifestResponse(manifest);
+
+        when(this.restTemplate.getForObject(ZIP_URL, byte[].class))
+                .thenReturn(null);
+
+        when(this.versionFactory.getVersions())
+                .thenReturn(new ConcurrentHashMap<>());
+
+        final UpgradeTask task =
+                new UpgradeTask(
+                        MANIFEST_URL,
+                        tempDir.toString(),
+                        Collections.singletonList(0),
+                        identifier -> "client-" + identifier,
+                        "MY_API_KEY",
+                        this.versionFactory,
+                        this.watchDog,
+                        this.restTemplate);
+
+        task.check();
+
+        // Stop is called as part of upgrade(), but no app folder should
+        // have been created.
+        verify(this.watchDog, times(1)).stopApp(
+                tempDir.toString() + File.separator + "0",
+                manifest.alias);
+        // No conf folder since extraction never happened
+        assertFalse(
+                Files.exists(
+                        tempDir.resolve("0")
+                                .resolve(manifest.alias + "-" + manifest.version)));
+        // startApp is still attempted - with a null version (the old version)
+        verify(this.watchDog, times(1)).startApp(
+                eq(tempDir.toString() + File.separator + "0"),
+                eq(manifest),
+                org.mockito.ArgumentMatchers.isNull());
+    }
+
+    /**
+     * Verifies that an existing prior version directory is wiped before a
+     * new version is unpacked.
+     */
+    @Test
+    void deletesPriorVersionsOnUpgrade(@TempDir final Path tempDir) throws Exception {
+        final AppManifest manifest =
+                buildManifest("2.0.0", "REPLACE_API", "REPLACE_ID");
+
+        // Pre-create the OLD version folder with a sentinel file
+        final Path identifierDir = tempDir.resolve("0");
+        final Path oldAppDir =
+                identifierDir.resolve(manifest.alias + "-1.0.0");
+        Files.createDirectories(oldAppDir);
+        Files.write(
+                oldAppDir.resolve("sentinel.txt"),
+                "this should be deleted".getBytes(StandardCharsets.UTF_8));
+
+        final byte[] zip =
+                buildZip(
+                        manifest.alias + "-" + manifest.version,
+                        "REPLACE_API REPLACE_ID");
+
+        stubManifestResponse(manifest);
+        stubZipResponse(zip);
+
+        final Map<String, Map<String, String>> versions = new HashMap<>();
+        final Map<String, String> distVersions = new HashMap<>();
+        distVersions.put(manifest.alias, "1.0.0");
+        versions.put("0", distVersions);
+        when(this.versionFactory.getVersions()).thenReturn(versions);
+
+        final UpgradeTask task =
+                new UpgradeTask(
+                        MANIFEST_URL,
+                        tempDir.toString(),
+                        Collections.singletonList(0),
+                        identifier -> "client-" + identifier,
+                        "MY_API_KEY",
+                        this.versionFactory,
+                        this.watchDog,
+                        this.restTemplate);
+
+        task.check();
+
+        assertFalse(
+                Files.exists(oldAppDir),
+                "old version directory should have been deleted");
+        assertTrue(
+                Files.isDirectory(
+                        identifierDir.resolve(manifest.alias + "-" + manifest.version)),
+                "new version directory should exist");
+    }
+
+    /**
+     * Verifies that, on upgrade, the prior conf is preserved (the new
+     * extracted conf is replaced with the old one before the placeholders
+     * are substituted).
+     */
+    @Test
+    void preservesPreviousConfOnUpgrade(@TempDir final Path tempDir) throws Exception {
+        final AppManifest manifest =
+                buildManifest("2.0.0", "REPLACE_API", "REPLACE_ID");
+
+        // Pre-existing 1.0.0 install with custom conf
+        final Path identifierDir = tempDir.resolve("0");
+        final Path oldAppDir =
+                identifierDir.resolve(manifest.alias + "-1.0.0");
+        final Path oldConfDir = oldAppDir.resolve("conf");
+        Files.createDirectories(oldConfDir);
+        Files.write(
+                oldConfDir.resolve(manifest.conf.file),
+                ("custom=preserved\napiKey=ABC\nclientId=XYZ")
+                        .getBytes(StandardCharsets.UTF_8));
+
+        // The zip's conf has placeholders that the test expects NOT to be
+        // used (because the old conf wins).
+        final byte[] zip =
+                buildZip(
+                        manifest.alias + "-" + manifest.version,
+                        "default=fresh\napiKey=REPLACE_API\nclientId=REPLACE_ID");
+
+        stubManifestResponse(manifest);
+        stubZipResponse(zip);
+
+        final Map<String, Map<String, String>> versions = new HashMap<>();
+        final Map<String, String> distVersions = new HashMap<>();
+        distVersions.put(manifest.alias, "1.0.0");
+        versions.put("0", distVersions);
+        when(this.versionFactory.getVersions()).thenReturn(versions);
+
+        final UpgradeTask task =
+                new UpgradeTask(
+                        MANIFEST_URL,
+                        tempDir.toString(),
+                        Collections.singletonList(0),
+                        identifier -> "client-" + identifier,
+                        "MY_API_KEY",
+                        this.versionFactory,
+                        this.watchDog,
+                        this.restTemplate);
+
+        task.check();
+
+        final Path newConfFile =
+                identifierDir
+                        .resolve(manifest.alias + "-" + manifest.version)
+                        .resolve("conf")
+                        .resolve(manifest.conf.file);
+        final String contents = Files.readString(newConfFile);
+
+        assertTrue(
+                contents.contains("custom=preserved"),
+                "old conf should have been preserved: " + contents);
+        // The old conf had no REPLACE_API/REPLACE_ID placeholders, so the
+        // existing literal values should remain.
+        assertTrue(contents.contains("apiKey=ABC"));
+        assertTrue(contents.contains("clientId=XYZ"));
+        assertFalse(
+                contents.contains("default=fresh"),
+                "fresh conf from the zip should NOT have been used");
+    }
+
+    /**
+     * Verifies that the {@code clientIdSupplier} receives the per-identifier
+     * value when running for multiple identifiers.
+     */
+    @Test
+    void clientIdSupplierIsCalledPerIdentifier(@TempDir final Path tempDir) throws Exception {
+        final AppManifest manifest =
+                buildManifest("2.0.0", "REPLACE_API", "REPLACE_ID");
+        final byte[] zip =
+                buildZip(
+                        manifest.alias + "-" + manifest.version,
+                        "REPLACE_ID");
+
+        stubManifestResponse(manifest);
+        stubZipResponse(zip);
+
+        when(this.versionFactory.getVersions())
+                .thenReturn(new ConcurrentHashMap<>());
+
+        final Map<String, String> seenIdentifiers = new LinkedHashMap<>();
+        final UpgradeTask task =
+                new UpgradeTask(
+                        MANIFEST_URL,
+                        tempDir.toString(),
+                        Arrays.asList(7, 9),
+                        identifier -> {
+                            seenIdentifiers.put(identifier, "client-" + identifier);
+                            return "client-" + identifier;
+                        },
+                        "MY_API_KEY",
+                        this.versionFactory,
+                        this.watchDog,
+                        this.restTemplate);
+
+        task.check();
+
+        // Both identifiers should have been processed
+        assertTrue(seenIdentifiers.containsKey("7"));
+        assertTrue(seenIdentifiers.containsKey("9"));
+
+        // Both folders should exist on disk with their per-identifier
+        // configuration written out
+        final Path conf7 = tempDir.resolve("7")
+                .resolve(manifest.alias + "-" + manifest.version)
+                .resolve("conf").resolve(manifest.conf.file);
+        final Path conf9 = tempDir.resolve("9")
+                .resolve(manifest.alias + "-" + manifest.version)
+                .resolve("conf").resolve(manifest.conf.file);
+
+        assertTrue(Files.exists(conf7));
+        assertTrue(Files.exists(conf9));
+
+        assertTrue(
+                Files.readString(conf7)
+                        .contains("client-7"));
+        assertTrue(
+                Files.readString(conf9)
+                        .contains("client-9"));
+    }
+
+    /**
+     * Verifies that the per-identifier pickaxe key found in
+     * {@code <agentDist>/<identifier>/foreman-pickaxe-*\/conf/pickaxe.yml}
+     * is appended to the manifest URL as {@code pickaxe_key=...}.
+     */
+    @Test
+    void appendsPickaxeKeyFromIdentifierDist(@TempDir final Path tempDir) {
+        installPickaxeYml(tempDir, "0", "foreman-pickaxe-1.0.0", "secret-key");
+
+        stubManifestResponse();
+
+        when(this.versionFactory.getVersions())
+                .thenReturn(new ConcurrentHashMap<>());
+
+        final UpgradeTask task =
+                new UpgradeTask(
+                        MANIFEST_URL,
+                        tempDir.toString(),
+                        Collections.singletonList(0),
+                        identifier -> "client-" + identifier,
+                        "MY_API_KEY",
+                        this.versionFactory,
+                        this.watchDog,
+                        this.restTemplate);
+
+        task.check();
+
+        verify(this.restTemplate, times(1)).getForObject(
+                MANIFEST_URL + "?pickaxe_key=secret-key",
+                AppManifest[].class);
+    }
+
+    /**
+     * Verifies that, with multiple identifiers, each one resolves and uses
+     * its own pickaxe key (i.e. one identifier's key never leaks into
+     * another identifier's manifest URL).
+     */
+    @Test
+    void usesPerIdentifierPickaxeKey(@TempDir final Path tempDir) {
+        installPickaxeYml(tempDir, "7", "foreman-pickaxe-1.0.0", "key-seven");
+        installPickaxeYml(tempDir, "9", "foreman-pickaxe-1.0.0", "key-nine");
+
+        stubManifestResponse();
+
+        when(this.versionFactory.getVersions())
+                .thenReturn(new ConcurrentHashMap<>());
+
+        final UpgradeTask task =
+                new UpgradeTask(
+                        MANIFEST_URL,
+                        tempDir.toString(),
+                        Arrays.asList(7, 9),
+                        identifier -> "client-" + identifier,
+                        "MY_API_KEY",
+                        this.versionFactory,
+                        this.watchDog,
+                        this.restTemplate);
+
+        task.check();
+
+        verify(this.restTemplate, times(1)).getForObject(
+                MANIFEST_URL + "?pickaxe_key=key-seven",
+                AppManifest[].class);
+        verify(this.restTemplate, times(1)).getForObject(
+                MANIFEST_URL + "?pickaxe_key=key-nine",
+                AppManifest[].class);
+    }
+
+    /**
+     * Verifies that the pickaxe key value is URL-encoded when embedded into
+     * the manifest URL.
+     */
+    @Test
+    void urlEncodesPickaxeKey(@TempDir final Path tempDir) {
+        installPickaxeYml(tempDir, "0", "foreman-pickaxe-1.0.0", "abc def&xyz");
+
+        stubManifestResponse();
+
+        when(this.versionFactory.getVersions())
+                .thenReturn(new ConcurrentHashMap<>());
+
+        final UpgradeTask task =
+                new UpgradeTask(
+                        MANIFEST_URL,
+                        tempDir.toString(),
+                        Collections.singletonList(0),
+                        identifier -> "client-" + identifier,
+                        "MY_API_KEY",
+                        this.versionFactory,
+                        this.watchDog,
+                        this.restTemplate);
+
+        task.check();
+
+        final org.mockito.ArgumentCaptor<String> urlCaptor =
+                org.mockito.ArgumentCaptor.forClass(String.class);
+        verify(this.restTemplate).getForObject(
+                urlCaptor.capture(),
+                eq(AppManifest[].class));
+
+        final String url = urlCaptor.getValue();
+        assertFalse(url.contains("abc def&xyz"), "raw value should not appear: " + url);
+        assertTrue(url.contains("abc+def") || url.contains("abc%20def"), url);
+        assertTrue(url.contains("%26"), "ampersand should be percent-encoded in: " + url);
+    }
+
+    /**
+     * Verifies that, when the configured base URL already has a query
+     * string, {@code pickaxe_key} is appended with {@code &} instead of
+     * {@code ?}.
+     */
+    @Test
+    void appendsWithAmpersandWhenBaseUrlHasQuery(@TempDir final Path tempDir) {
+        installPickaxeYml(tempDir, "0", "foreman-pickaxe-1.0.0", "the-key");
+
+        final String baseWithQuery = MANIFEST_URL + "?foo=bar";
+        when(this.restTemplate.getForObject(
+                argThat((String url) -> url != null && url.startsWith(baseWithQuery)),
+                eq(AppManifest[].class)))
+                .thenReturn(new AppManifest[0]);
+
+        when(this.versionFactory.getVersions())
+                .thenReturn(new ConcurrentHashMap<>());
+
+        final UpgradeTask task =
+                new UpgradeTask(
+                        baseWithQuery,
+                        tempDir.toString(),
+                        Collections.singletonList(0),
+                        identifier -> "client-" + identifier,
+                        "MY_API_KEY",
+                        this.versionFactory,
+                        this.watchDog,
+                        this.restTemplate);
+
+        task.check();
+
+        verify(this.restTemplate).getForObject(
+                baseWithQuery + "&pickaxe_key=the-key",
+                AppManifest[].class);
+    }
+
+    /**
+     * Verifies that a malformed (non-mapping) {@code pickaxe.yml} is
+     * silently tolerated and treated as no key (so the
+     * {@code pickaxe_key} query parameter is omitted entirely).
+     */
+    @Test
+    void malformedPickaxeYmlIsTolerated(@TempDir final Path tempDir) throws Exception {
+        final Path scaleDir = tempDir.resolve("0");
+        final Path pickaxeDir = scaleDir.resolve("foreman-pickaxe-1.0.0");
+        final Path confDir = pickaxeDir.resolve("conf");
+        Files.createDirectories(confDir);
+        Files.write(
+                confDir.resolve("pickaxe.yml"),
+                "just a string".getBytes(StandardCharsets.UTF_8));
+
+        stubManifestResponse();
+
+        when(this.versionFactory.getVersions())
+                .thenReturn(new ConcurrentHashMap<>());
+
+        final UpgradeTask task =
+                new UpgradeTask(
+                        MANIFEST_URL,
+                        tempDir.toString(),
+                        Collections.singletonList(0),
+                        identifier -> "client-" + identifier,
+                        "MY_API_KEY",
+                        this.versionFactory,
+                        this.watchDog,
+                        this.restTemplate);
+
+        task.check();
+
+        verify(this.restTemplate).getForObject(
+                MANIFEST_URL,
+                AppManifest[].class);
+    }
+
+    /**
+     * Verifies that an empty {@code pickaxeId} field in {@code pickaxe.yml}
+     * is treated as no key (so the {@code pickaxe_key} query parameter is
+     * omitted entirely).
+     */
+    @Test
+    void emptyPickaxeIdOmitsQueryParam(@TempDir final Path tempDir) {
+        installPickaxeYml(tempDir, "0", "foreman-pickaxe-1.0.0", "");
+
+        stubManifestResponse();
+
+        when(this.versionFactory.getVersions())
+                .thenReturn(new ConcurrentHashMap<>());
+
+        final UpgradeTask task =
+                new UpgradeTask(
+                        MANIFEST_URL,
+                        tempDir.toString(),
+                        Collections.singletonList(0),
+                        identifier -> "client-" + identifier,
+                        "MY_API_KEY",
+                        this.versionFactory,
+                        this.watchDog,
+                        this.restTemplate);
+
+        task.check();
+
+        verify(this.restTemplate).getForObject(
+                MANIFEST_URL,
+                AppManifest[].class);
+    }
+
+    /**
+     * Writes a {@code pickaxe.yml} file with the given {@code pickaxeId} at
+     * {@code <agentDist>/<identifier>/<appName>/conf/pickaxe.yml}.
+     */
+    private static void installPickaxeYml(
+            final Path agentDist,
+            final String identifier,
+            final String appName,
+            final String pickaxeId) {
+        try {
+            final Path confDir =
+                    agentDist
+                            .resolve(identifier)
+                            .resolve(appName)
+                            .resolve("conf");
+            Files.createDirectories(confDir);
+            Files.write(
+                    confDir.resolve("pickaxe.yml"),
+                    ("pickaxeId: \"" + pickaxeId + "\"\n")
+                            .getBytes(StandardCharsets.UTF_8));
+        } catch (final Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /** Builds a simple manifest fixture. */
+    private static AppManifest buildManifest(
+            final String version,
+            final String apiKeyPattern,
+            final String clientIdPattern) {
+        final AppManifest manifest = new AppManifest();
+        manifest.alias = "foreman-pickaxe";
+        manifest.app = "Foreman Pickaxe";
+        manifest.executable = "pickaxe.bat";
+        manifest.version = version;
+        manifest.windows = true;
+
+        final AppManifest.Github github = new AppManifest.Github();
+        github.name = manifest.alias + "-" + version + ".zip";
+        github.zipUrl = ZIP_URL;
+        manifest.github = github;
+
+        final AppManifest.Conf conf = new AppManifest.Conf();
+        conf.file = "pickaxe.yml";
+        conf.apiKeyPattern = apiKeyPattern;
+        conf.clientIdPattern = clientIdPattern;
+        manifest.conf = conf;
+
+        return manifest;
+    }
+
+    /**
+     * Builds a zip file that contains a single app folder with a {@code conf}
+     * subfolder containing the conf file and a {@code bin} subfolder
+     * containing the executable.
+     */
+    private static byte[] buildZip(
+            final String topLevel,
+            final String confContents) throws Exception {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+             ZipOutputStream zos = new ZipOutputStream(baos)) {
+
+            zos.putNextEntry(new ZipEntry(topLevel + "/"));
+            zos.closeEntry();
+
+            zos.putNextEntry(new ZipEntry(topLevel + "/conf/"));
+            zos.closeEntry();
+
+            zos.putNextEntry(new ZipEntry(topLevel + "/conf/pickaxe.yml"));
+            zos.write(confContents.getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+
+            zos.putNextEntry(new ZipEntry(topLevel + "/bin/"));
+            zos.closeEntry();
+
+            zos.putNextEntry(new ZipEntry(topLevel + "/bin/pickaxe.bat"));
+            zos.write("@echo off\n".getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+
+            zos.finish();
+            return baos.toByteArray();
+        }
+    }
+
+    /**
+     * Stubs every manifest GET (any URL that starts with {@link
+     * #MANIFEST_URL}, including ones with the {@code ?pickaxe_key=...}
+     * query parameter appended by {@link UpgradeTask}).
+     */
+    private void stubManifestResponse(final AppManifest... manifests) {
+        when(this.restTemplate.getForObject(
+                argThat((String url) -> url != null && url.startsWith(MANIFEST_URL)),
+                eq(AppManifest[].class)))
+                .thenReturn(manifests);
+    }
+
+    /** Stubs the zip download URL response. */
+    private void stubZipResponse(final byte[] zip) {
+        when(this.restTemplate.getForObject(ZIP_URL, byte[].class))
+                .thenReturn(zip);
+    }
+}

--- a/src/test/java/mn/foreman/windowsagent/upgrade/UpgraderTest.java
+++ b/src/test/java/mn/foreman/windowsagent/upgrade/UpgraderTest.java
@@ -1,0 +1,213 @@
+package mn.foreman.windowsagent.upgrade;
+
+import mn.foreman.api.ForemanApi;
+import mn.foreman.api.endpoints.groups.Groups;
+import mn.foreman.windowsagent.VersionFactory;
+import mn.foreman.windowsagent.foreman.AppManifest;
+import mn.foreman.windowsagent.process.WatchDog;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.web.client.RestTemplate;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link Upgrader}.
+ *
+ * <p>{@link Upgrader} is just an orchestrator - it builds {@link
+ * UpgradeTask} instances and runs them.  Manifest URL building, pickaxe key
+ * resolution and conf handling all live in {@link UpgradeTask}.  These tests
+ * therefore exercise only the orchestration concerns: how many tasks are
+ * built (private vs. colo), which identifiers each task receives, and when
+ * the foreman API is consulted for sub-clients.
+ */
+class UpgraderTest {
+
+    /** The base manifest URL passed in via configuration. */
+    private static final String BASE_MANIFEST_URL =
+            "https://example.com/api/manifest";
+
+    /** Mocks. */
+    private RestTemplate restTemplate;
+    private VersionFactory privateVersionFactory;
+    private VersionFactory coloVersionFactory;
+    private ForemanApi foremanApi;
+    private WatchDog watchDog;
+
+    @BeforeEach
+    void setUp() {
+        this.restTemplate = mock(RestTemplate.class);
+        this.privateVersionFactory = mock(VersionFactory.class);
+        this.coloVersionFactory = mock(VersionFactory.class);
+        this.foremanApi = mock(ForemanApi.class);
+        this.watchDog = mock(WatchDog.class);
+
+        when(this.privateVersionFactory.getVersions())
+                .thenReturn(new ConcurrentHashMap<>());
+        when(this.coloVersionFactory.getVersions())
+                .thenReturn(new ConcurrentHashMap<>());
+        when(this.restTemplate.getForObject(
+                anyString(),
+                eq(AppManifest[].class)))
+                .thenReturn(new AppManifest[0]);
+    }
+
+    /**
+     * Verifies that, when colo is disabled, only the private task runs
+     * (one manifest GET per private identifier) and the colo API is never
+     * consulted.
+     */
+    @Test
+    void coloDisabledRunsOnlyPrivateTask(@TempDir final Path tempDir) {
+        final int scale = 3;
+        final Upgrader upgrader =
+                newUpgrader(tempDir, scale, /* coloEnabled */ false);
+
+        upgrader.check();
+
+        // One manifest GET per private identifier, no colo work
+        verify(this.restTemplate, times(scale)).getForObject(
+                anyString(), eq(AppManifest[].class));
+        verify(this.privateVersionFactory, times(1)).getVersions();
+        verify(this.coloVersionFactory, never()).getVersions();
+        verifyNoInteractions(this.foremanApi);
+    }
+
+    /**
+     * Verifies that, with colo enabled and sub-clients returned, the colo
+     * task runs in addition to the private task: one manifest GET per
+     * private identifier plus one per sub-client.
+     */
+    @Test
+    void coloEnabledFetchesSubClientsAndIssuesAdditionalChecks(@TempDir final Path tempDir) {
+        final Groups groups = mock(Groups.class);
+        final Groups.GroupInfo info = new Groups.GroupInfo();
+        final Groups.GroupInfo.SubClient subA = new Groups.GroupInfo.SubClient();
+        subA.id = 11;
+        final Groups.GroupInfo.SubClient subB = new Groups.GroupInfo.SubClient();
+        subB.id = 12;
+        info.subClients = Arrays.asList(subA, subB);
+
+        when(groups.groups()).thenReturn(Optional.of(info));
+        when(this.foremanApi.groups()).thenReturn(groups);
+
+        final int scale = 1;
+        final Upgrader upgrader =
+                newUpgrader(tempDir, scale, /* coloEnabled */ true);
+
+        upgrader.check();
+
+        // 1 private GET + 2 colo GETs = 3 total
+        verify(this.restTemplate, times(scale + info.subClients.size()))
+                .getForObject(anyString(), eq(AppManifest[].class));
+
+        verify(this.privateVersionFactory, times(1)).getVersions();
+        verify(this.coloVersionFactory, times(1)).getVersions();
+        verify(this.foremanApi, times(1)).groups();
+    }
+
+    /**
+     * Verifies that, with colo enabled but no sub-clients, the colo task is
+     * not run (no extra manifest GET, colo version factory not consulted).
+     */
+    @Test
+    void coloEnabledWithoutSubClientsSkipsColoTask(@TempDir final Path tempDir) {
+        final Groups groups = mock(Groups.class);
+        when(groups.groups()).thenReturn(Optional.empty());
+        when(this.foremanApi.groups()).thenReturn(groups);
+
+        final int scale = 2;
+        final Upgrader upgrader =
+                newUpgrader(tempDir, scale, /* coloEnabled */ true);
+
+        upgrader.check();
+
+        verify(this.restTemplate, times(scale)).getForObject(
+                anyString(), eq(AppManifest[].class));
+        verify(this.coloVersionFactory, never()).getVersions();
+        verify(this.foremanApi, times(1)).groups();
+    }
+
+    /**
+     * Verifies that, with colo enabled and a {@code GroupInfo} that has a
+     * {@code null} sub-clients list, no colo task is run.
+     */
+    @Test
+    void coloEnabledWithNullSubClientsListIsTolerated(@TempDir final Path tempDir) {
+        final Groups groups = mock(Groups.class);
+        final Groups.GroupInfo info = new Groups.GroupInfo();
+        info.subClients = null;
+
+        when(groups.groups()).thenReturn(Optional.of(info));
+        when(this.foremanApi.groups()).thenReturn(groups);
+
+        final Upgrader upgrader =
+                newUpgrader(tempDir, /* scale */ 1, /* coloEnabled */ true);
+
+        upgrader.check();
+
+        verify(this.restTemplate, times(1)).getForObject(
+                anyString(), eq(AppManifest[].class));
+        verify(this.coloVersionFactory, never()).getVersions();
+    }
+
+    /**
+     * Verifies that the manifest URL passed in via configuration is used as
+     * the base for outgoing requests (i.e. it is not modified by {@link
+     * Upgrader} itself - any modification is the {@link UpgradeTask}'s
+     * responsibility).
+     */
+    @Test
+    void manifestUrlIsPassedThroughToTasks(@TempDir final Path tempDir) {
+        final Upgrader upgrader =
+                newUpgrader(tempDir, /* scale */ 1, /* coloEnabled */ false);
+
+        upgrader.check();
+
+        final org.mockito.ArgumentCaptor<String> urlCaptor =
+                org.mockito.ArgumentCaptor.forClass(String.class);
+        verify(this.restTemplate).getForObject(
+                urlCaptor.capture(),
+                eq(AppManifest[].class));
+
+        // The URL the task fetches is the base + whatever query params it
+        // wants to add - but it must always start with the base URL.
+        org.junit.jupiter.api.Assertions.assertTrue(
+                urlCaptor.getValue().startsWith(BASE_MANIFEST_URL),
+                urlCaptor.getValue());
+    }
+
+    /** Convenience for building an {@link Upgrader} with the test mocks. */
+    private Upgrader newUpgrader(
+            final Path tempDir,
+            final int scale,
+            final boolean coloEnabled) {
+        return new Upgrader(
+                BASE_MANIFEST_URL,
+                "client-id",
+                "API_KEY",
+                tempDir.resolve("private").toString(),
+                scale,
+                coloEnabled,
+                tempDir.resolve("colo").toString(),
+                this.privateVersionFactory,
+                this.coloVersionFactory,
+                this.foremanApi,
+                this.watchDog,
+                this.restTemplate);
+    }
+}


### PR DESCRIPTION
Adding the pickaxe id to the manifest request allows the backend to override the global version of pickaxe per pickaxe

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how and how often manifest is fetched and what the backend sees for version selection; behavior is well-tested but affects production upgrades and couples to a large `java-api` version jump.
> 
> **Overview**
> **Upgrade polling** now fetches `/api/manifest` **once per scale identifier** instead of a single shared request. For each identifier, `UpgradeTask` looks under that identifier’s dist for a `foreman-pickaxe-*` install, reads `pickaxeId` from `conf/pickaxe.yml`, and appends it as a URL-encoded `pickaxe_key` query parameter when present (using `&` if the base URL already has a query string). If there is no pickaxe, no id, or the YAML is invalid/empty, the manifest URL is left unchanged so the backend can still serve the global manifest.
> 
> **Dependencies:** `foreman.version` in `pom.xml` is bumped from `1.38.0` to `1.86.0`.
> 
> **Tests:** Large new JUnit coverage for `UpgradeTask` (install/upgrade/skip paths and `pickaxe_key` behavior), plus tests for `Upgrader`, `WatchDog`, `AppImpl`, `FileUtils`, `VersionFactoryImpl`, `AppManifest`, and `AppFolder`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6913d87bf618e506ed908aecc1cb31ca4d12976b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->